### PR TITLE
Add sanitation on `assetId` inputs for RPC images and add function documentation

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -19,12 +19,27 @@ export type RichPresence = {
 }
 
 export type RichPresenceImage = {
-	assetId: number?,
+	assetId: number? | string?,
 	hoverText: string?,
 	clear: boolean?,
 	reset: boolean?,
 }
 
+--[=[
+	Removes any non-number characters from AssetId, useful if the developer is passing in a ID that is taken directly from Instances like Decals or ImageLabels that contain `rbxassetid` or a URL like `http://www.roblox.com/asset/?id=`.
+]=]
+function SanitiseAssetId(assetId: string): number?
+	if type(assetId) ~= "string" then
+		return assetId
+	end
+
+	return tonumber(string.match(assetId, "%d+"))
+end
+
+--[=[
+	Send a raw RPC message.
+	Avoid using this, as every command available will have a dedicated function for it.
+]=]
 function BloxstrapRPC.SendMessage(command: string, data: any)
 	local json = HttpService:JSONEncode({
 		command = command,
@@ -34,13 +49,22 @@ function BloxstrapRPC.SendMessage(command: string, data: any)
 	print("[BloxstrapRPC] " .. json)
 end
 
+--[=[
+	Change or reset the user's Rich Presence activity if they are running Bloxstrap with the option enabled.
+]=]
 function BloxstrapRPC.SetRichPresence(data: RichPresence)
 	if data.timeStart ~= nil then
 		data.timeStart = math.round(data.timeStart)
 	end
-
 	if data.timeEnd ~= nil then
 		data.timeEnd = math.round(data.timeEnd)
+	end
+
+	if data.smallImage ~= nil then
+		data.smallImage.assetId = SanitiseAssetId(data.smallImage.assetId)
+	end
+	if data.largeImage ~= nil then
+		data.largeImage.assetId = SanitiseAssetId(data.largeImage.assetId)
 	end
 
 	BloxstrapRPC.SendMessage("SetRichPresence", data)


### PR DESCRIPTION
Bloxstrap will fail to display RPC if any RPC images have `assetId` parameters which contain values that are not numbers, this can be troublesome if the game developer wishes to pass a `Texture` property of a Decal instance, which will contain `rbxassetid://<Actual ID here>` instead of just the ID itself. This sanitation function aims to fix that, even with Roblox asset URLs as well.

The sanitation function was tested with the following: 
```luau
SetRichPresence({
	details = "test",
	state = "test2",
	smallImage = {
		assetId = "http://www.roblox.com/asset/?id=29536967",
		hoverText = "testHover"
	},
	largeImage = {
		assetId = "rbxassetid://29536967",
		hoverText = "testHover2"
	}
})
```
And the result works: 
![image](https://github.com/bloxstraplabs/bloxstrap-rpc-sdk/assets/31796727/2b421b8b-8ec1-45dd-a3b7-437284b788be)

I also added function documentation which is available via a FastFlag (`FFlagAutocompleteUserDefinedFunctionDocumentation`), I added it for the future when the feature is fully integrated into Studio.
![image](https://github.com/bloxstraplabs/bloxstrap-rpc-sdk/assets/31796727/39857960-9f88-4852-b158-d5e87fc4331b)
