### PR TITLE
Fix type declaration for `assetId` to resolve Luau syntax error

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -19,7 +19,7 @@ export type RichPresence = {
 }
 
 export type RichPresenceImage = {
-	assetId: number? | string?,
+	assetId: (number | string)?,
 	hoverText: string?,
 	clear: boolean?,
 	reset: boolean?,


### PR DESCRIPTION
Fixes the `assetId` type by wrapping `number | string` in parentheses to resolve a Luau syntax error.

**Old**:
```lua
number? | string?
```

**New**:
```lua
(number | string)?
```

[src/init.lua, Ln 22](https://github.com/bloxstraplabs/bloxstrap-rpc-sdk/blob/6a391d8d4bbaa3ca6b4ddd5cc9cbede99a072b36/src/init.lua#L22C11-L22C28)